### PR TITLE
Store safe head on storage

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -217,6 +217,22 @@ func WriteHeadFastBlockHash(db ethdb.KeyValueWriter, hash common.Hash) {
 	}
 }
 
+// ReadSafeBlockHash retrieves the hash of the finalized block.
+func ReadSafeBlockHash(db ethdb.KeyValueReader) common.Hash {
+	data, _ := db.Get(headSafeBlockKey)
+	if len(data) == 0 {
+		return common.Hash{}
+	}
+	return common.BytesToHash(data)
+}
+
+// WriteSafeBlockHash stores the hash of the finalized block.
+func WriteSafeBlockHash(db ethdb.KeyValueWriter, hash common.Hash) {
+	if err := db.Put(headSafeBlockKey, hash.Bytes()); err != nil {
+		log.Crit("Failed to store last finalized block's hash", "err", err)
+	}
+}
+
 // ReadFinalizedBlockHash retrieves the hash of the finalized block.
 func ReadFinalizedBlockHash(db ethdb.KeyValueReader) common.Hash {
 	data, _ := db.Get(headFinalizedBlockKey)

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -40,6 +40,9 @@ var (
 	// headFastBlockKey tracks the latest known incomplete block's hash during fast sync.
 	headFastBlockKey = []byte("LastFast")
 
+	// headSafeBlockKey tracks the latest known safe block hash.
+	headSafeBlockKey = []byte("LastSafe")
+
 	// headFinalizedBlockKey tracks the latest known finalized block hash.
 	headFinalizedBlockKey = []byte("LastFinalized")
 


### PR DESCRIPTION
To prevent the `op-node` from starting to sync from the finalized block in Oasys, which is always zero due to the absence of a finalization mechanism, the safe head should be recorded in storage and then loaded during startup.