### PR TITLE
Fixed panic when setting CanyonTime via environment variable

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -262,7 +262,7 @@ var (
 		Usage:    "Manually specify the Verkle fork timestamp, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
-	OverrideOptimismCanyon = &flags.BigFlag{
+	OverrideOptimismCanyon = &cli.Uint64Flag{
 		Name:     "override.canyon",
 		Usage:    "Manually specify the Optimsim Canyon fork timestamp, overriding the bundled setting",
 		Category: flags.EthCategory,


### PR DESCRIPTION
panic log
```
op-geth-1  | panic: runtime error: invalid memory address or nil pointer dereference
op-geth-1  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x527c50]
op-geth-1  | 
op-geth-1  | goroutine 1 [running]:
op-geth-1  | math/big.(*Int).scan(0x0, {0x1e822e0, 0x400022a8a0}, 0x17173c0?)
op-geth-1  |    math/big/intconv.go:188 +0x40
op-geth-1  | math/big.(*Int).setFromScanner(0x1004000031a28?, {0x1e822e0, 0x400022a8a0}, 0x4bd700?)
op-geth-1  |    math/big/int.go:502 +0x28
op-geth-1  | math/big.(*Int).SetString(0x4000148588?, {0x400004202d, 0x1}, 0x40c8b8?)
op-geth-1  |    math/big/int.go:496 +0x84
op-geth-1  | github.com/ethereum/go-ethereum/internal/flags.(*BigFlag).Apply(0x2a18800, 0x4000475260)
op-geth-1  |    github.com/ethereum/go-ethereum/internal/flags/flags.go:275 +0xa4
op-geth-1  | github.com/urfave/cli/v2.flagSet({0xffffff7d8d4a, 0x4}, {0x400052c000, 0xb3, 0x18?}, {{0x0?, 0x40005a7ab8?}, 0x0?, 0x0?})
op-geth-1  |    github.com/urfave/cli/v2@v2.25.7/flag.go:177 +0x150
op-geth-1  | github.com/urfave/cli/v2.(*Command).newFlagSet(...)
op-geth-1  |    github.com/urfave/cli/v2@v2.25.7/command.go:281
op-geth-1  | github.com/urfave/cli/v2.(*Command).parseFlags(0x40001ac000, {0x1e8ca28, 0x40005a7ab8}, 0x94?)
op-geth-1  |    github.com/urfave/cli/v2@v2.25.7/command.go:314 +0x64
op-geth-1  | github.com/urfave/cli/v2.(*Command).Run(0x40001ac000, 0x400031a8c0, {0x400003c0d0, 0x1, 0x1})
op-geth-1  |    github.com/urfave/cli/v2@v2.25.7/command.go:155 +0xa8
op-geth-1  | github.com/urfave/cli/v2.(*App).RunContext(0x40003845a0, {0x1e89088?, 0x2c1d720}, {0x400003c0d0, 0x1, 0x1})
op-geth-1  |    github.com/urfave/cli/v2@v2.25.7/app.go:332 +0x518
op-geth-1  | github.com/urfave/cli/v2.(*App).Run(...)
op-geth-1  |    github.com/urfave/cli/v2@v2.25.7/app.go:309
op-geth-1  | main.main()
op-geth-1  |    github.com/ethereum/go-ethereum/cmd/geth/main.go:279 +0x4c
```