### PR TITLE
Fix fork order check error for MCHVerse

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -485,6 +485,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	// OP-Stack warning: tricky upstream code: method with nil-receiver case.
 	// Returns genesis.Config if genesis is not nil. Falls back to storedCfg otherwise. And some special L1 cases.
 	newCfg := genesis.chainConfigOrDefault(ghash, storedCfg)
+	if err := overrides.apply(newCfg); err != nil {
+		return nil, common.Hash{}, nil, err
+	}
 
 	// Sanity-check the new configuration.
 	if err := newCfg.CheckConfigForkOrder(); err != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -965,7 +965,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "petersburgBlock", block: c.PetersburgBlock},
 		{name: "istanbulBlock", block: c.IstanbulBlock},
 		{name: "muirGlacierBlock", block: c.MuirGlacierBlock, optional: true},
-		{name: "berlinBlock", block: c.BerlinBlock},
+		{name: "berlinBlock", block: c.BerlinBlock, optional: c.IsMCHVerse},
 		{name: "londonBlock", block: c.LondonBlock},
 		{name: "arrowGlacierBlock", block: c.ArrowGlacierBlock, optional: true},
 		{name: "grayGlacierBlock", block: c.GrayGlacierBlock, optional: true},


### PR DESCRIPTION
Fix startup errors for MCHVerse.
```
Fatal: Failed to register the Ethereum service: unsupported fork ordering: berlinBlock not enabled, but londonBlock enabled at block 48369
```

The upstream also has the same fix.
https://github.com/ethereum-optimism/op-geth/commit/a511553e448c947a0fe8f34acf7bb6f9818c2b49